### PR TITLE
Added nodeTypes within package itself without requesting for xdom.ts

### DIFF
--- a/src/ts/xdom2jso.ts
+++ b/src/ts/xdom2jso.ts
@@ -1,8 +1,19 @@
-///<reference path="../../node_modules/autopulous-xdom/xdom.ts"/>
-
-import nodeTypes = xdom.nodeTypes;
-
 module xdom2jso {
+    export enum nodeTypes {
+        UNDEFINED = 0,
+        ELEMENT = 1,
+        ATTRIBUTE = 2,
+        TEXT = 3,
+        CDATA_SECTION = 4,
+        ENTITY_REFERENCE = 5,
+        ENTITY = 6,
+        PROCESSING_INSTRUCTION = 7,
+        COMMENT = 8,
+        DOCUMENT = 9,
+        DOCUMENT_TYPE = 10,
+        DOCUMENT_FRAGMENT = 11,
+        NOTATION = 12
+    }
     export function convert(xmlRoot:Node, localName?:boolean):{} {
         if (undefined !== localName) this.localName = localName;
 


### PR DESCRIPTION
Hi @Neoheurist ,

I would suggest this change to be merged in, even though a minor one. It does make a lot of difference, as this repo is no more in consistency with the latest release of xdom, which exports the namespace as XDom resulting to 'Uncaught ReferenceError: xdom is not defined' while running the application.

As the only dependency of this repo with xdom.ts is importing nodeTypes, why not go ahead and use it here. Please do consider this at the earliest.